### PR TITLE
Add dynamic option to authorize_params

### DIFF
--- a/lib/omniauth/strategies/weibo.rb
+++ b/lib/omniauth/strategies/weibo.rb
@@ -43,6 +43,15 @@ module OmniAuth
         @raw_info ||= access_token.get("/2/users/show.json", :params => {:uid => @uid}).parsed
       end
       
+      alias :old_request_phase :request_phase
+      def request_phase
+        display = session['omniauth.params']['display']
+        if display
+          options[:authorize_params].merge!(:display => display)
+        end
+        old_request_phase
+      end
+      
     end
   end
 end


### PR DESCRIPTION
You can add display option to authorize on specified page, for example, if you want to on mobile page, you can use url like 'auth/weibo?display=mobile'.

All display options are in this from weibo, http://open.weibo.com/wiki/Oauth2/authorize
