### PR TITLE
重写获取access_token方法

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .bundle
 *.swp
+.gem
 Gemfile.lock

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ end
 you can set up redirect_uri in `omniauth.rb` as following:
 
 ```ruby
-provider :weibo, ENV['WEIBO_API'], ENV['WEIBO_SECRET'],
+provider :weibo, ENV['WEIBO_KEY'], ENV['WEIBO_SECRET'],
          token_params: {redirect_uri: "http://127.0.0.1:3000/auth/weibo/callback" }
 ```
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,14 @@ Rails.application.config.middleware.use OmniAuth::Builder do
   provider :weibo, ENV['WEIBO_KEY'], ENV['WEIBO_SECRET']
 end
 ```
+## Configuration
+
+you can set up redirect_uri in `omniauth.rb` as following:
+
+```ruby
+provider :weibo, ENV['WEIBO_API'], ENV['WEIBO_SECRET'],
+         token_params: {redirect_uri: "http://127.0.0.1:3000/auth/weibo/callback" }
+```
 
 ## Authentication Hash
 

--- a/lib/omniauth-weibo-oauth2/version.rb
+++ b/lib/omniauth-weibo-oauth2/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
   module WeiboOauth2
-    VERSION = "0.4.0"
+    VERSION = "0.4.1"
   end
 end

--- a/lib/omniauth/strategies/weibo.rb
+++ b/lib/omniauth/strategies/weibo.rb
@@ -6,7 +6,8 @@ module OmniAuth
       option :client_options, {
         :site           => "https://api.weibo.com",
         :authorize_url  => "/oauth2/authorize",
-        :token_url      => "/oauth2/access_token"
+        :token_url      => "/oauth2/access_token",
+        :token_method => :post
       }
       option :token_params, {
         :parse          => :json
@@ -63,7 +64,18 @@ module OmniAuth
           end
         end
       end
-      
+
+      protected
+      def build_access_token
+        params = {
+          'client_id' => client.id,
+          'client_secret' => client.secret,
+          'code' => request.params['code'],
+          'grant_type' => 'authorization_code'
+        }.merge(token_params.to_hash(symbolize_keys: true))
+        client.get_token(params, deep_symbolize(options.auth_token_params))
+      end
+
     end
   end
 end


### PR DESCRIPTION
weibo 的 access_token 方法改为 Post 请求。
修复 redirect_uri_mismatch 错误，改为指定重定向地址（redirect_uri）。