### PR TITLE
Fix options[:image_size] has nil valud cause to symbol failed

### DIFF
--- a/lib/omniauth/strategies/weibo.rb
+++ b/lib/omniauth/strategies/weibo.rb
@@ -55,14 +55,15 @@ module OmniAuth
       #                     small     30x30
       #default is middle
       def image_url
-        case options[:image_size].to_sym
+        image_size = options[:image_size] || :middle
+        case image_size.to_sym
         when :original
           url = raw_info['avatar_hd']
         when :large
           url = raw_info['avatar_large']
         when :small
           url = raw_info['avatar_large'].sub('/180/','/30/')
-        else 
+        else
           url = raw_info['profile_image_url']
         end
       end


### PR DESCRIPTION
As title, when the `options[:image_size]` not set, it would be `nil` and cause `to_sym` method throw error.
