### PR TITLE
Add redirect_uri to access_token params

### DIFF
--- a/lib/omniauth/strategies/weibo.rb
+++ b/lib/omniauth/strategies/weibo.rb
@@ -91,7 +91,8 @@ module OmniAuth
           'client_id' => client.id,
           'client_secret' => client.secret,
           'code' => request.params['code'],
-          'grant_type' => 'authorization_code'
+          'grant_type' => 'authorization_code',
+          'redirect_uri' => options['redirect_uri']
         }.merge(token_params.to_hash(symbolize_keys: true))
         client.get_token(params, deep_symbolize(options.auth_token_params))
       end


### PR DESCRIPTION
Without the redirect_uri, the Oauth flow cannot complete. I believe this addresses #21 (but I'm translating via Google Translate, so I may have misunderstood their issue). I've gotten this successfully working myself using this patch. 