### PR TITLE
Unpin omniauth dependencies

### DIFF
--- a/omniauth-weibo-oauth2.gemspec
+++ b/omniauth-weibo-oauth2.gemspec
@@ -16,6 +16,6 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = OmniAuth::WeiboOauth2::VERSION
 
-  gem.add_dependency 'omniauth', '~> 1.5'
-  gem.add_dependency 'omniauth-oauth2', '>= 1.4.0'
+  gem.add_dependency 'omniauth'
+  gem.add_dependency 'omniauth-oauth2'
 end


### PR DESCRIPTION
By unpinning omniauth dependencies, it is possible to upgrade to more recent versions of `omniauth` and `omniauth-oauth2` gems in projects that are depending on this strategy.

Granted, the compatibility with newer versions might not be guaranteed, but at least it will not limit downstream projects to outdated gems, with potential unfixed security issues.

Thanks for considering!